### PR TITLE
Api call

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,21 +13,6 @@ ij_formatter_tags_enabled = false
 ij_smart_tabs = false
 ij_wrap_on_typing = false
 
-[*.conf]
-indent_size = 2
-tab_width = 2
-ij_continuation_indent_size = 2
-ij_hocon_keep_blank_lines_before_right_brace = 2
-ij_hocon_keep_indents_on_empty_lines = false
-ij_hocon_keep_line_breaks = true
-ij_hocon_space_after_colon = true
-ij_hocon_space_after_comma = true
-ij_hocon_space_before_colon = true
-ij_hocon_space_before_comma = false
-ij_hocon_spaces_within_braces = false
-ij_hocon_spaces_within_brackets = false
-ij_hocon_spaces_within_method_call_parentheses = false
-
 [*.java]
 ij_java_align_consecutive_assignments = false
 ij_java_align_consecutive_variable_declarations = false
@@ -487,8 +472,8 @@ ij_kotlin_method_call_chain_wrap = off
 ij_kotlin_method_parameters_new_line_after_left_paren = false
 ij_kotlin_method_parameters_right_paren_on_new_line = false
 ij_kotlin_method_parameters_wrap = off
-ij_kotlin_name_count_to_use_star_import = 5
-ij_kotlin_name_count_to_use_star_import_for_members = 3
+ij_kotlin_name_count_to_use_star_import = 20
+ij_kotlin_name_count_to_use_star_import_for_members = 20
 ij_kotlin_parameter_annotation_wrap = off
 ij_kotlin_space_after_comma = true
 ij_kotlin_space_after_extend_colon = true

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This repository contains an Android application that allows user to perform a lo
 
 ![UIpreview](docs/UIpreview.png) 
 
+Since the API is not ready a Fake implementation of the API client will be provided. As the contract of the API is already defined, We will implement also a Real ApiClient that will be tested using **HttpStubbing** with _MockWebServer_.
+
 ## CI
 
 Several CI checks are set up yo guarantee code style and code quality standards are fulfilled.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,8 +34,14 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
 
     implementation "io.arrow-kt:arrow-core-data:$arrow_version"
+    implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
+    implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
+    implementation "com.google.code.gson:gson:$gson_version"
 
     testImplementation "junit:junit:$junit_version"
     testImplementation "io.kotlintest:kotlintest:$kotlintest_version"
     testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "com.squareup.okhttp3:mockwebserver:$mockwebserver_version"
+    testImplementation "commons-io:commons-io:$commonsio_version"
+
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,5 +33,9 @@ dependencies {
     implementation "androidx.core:core-ktx:$corektx_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
 
+    implementation "io.arrow-kt:arrow-core-data:$arrow_version"
+
     testImplementation "junit:junit:$junit_version"
+    testImplementation "io.kotlintest:kotlintest:$kotlintest_version"
+    testImplementation "io.mockk:mockk:$mockk_version"
 }

--- a/app/src/main/java/com/ikarimeister/loginapp/data/LoginApiClient.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/data/LoginApiClient.kt
@@ -1,0 +1,11 @@
+package com.ikarimeister.loginapp.data
+
+import arrow.core.Either
+import com.ikarimeister.loginapp.domain.model.LoginError
+import com.ikarimeister.loginapp.domain.model.Token
+import com.ikarimeister.loginapp.domain.model.User
+
+interface LoginApiClient {
+
+    fun login(user: User): Either<LoginError, Token>
+}

--- a/app/src/main/java/com/ikarimeister/loginapp/data/network/FakeLoginApiClient.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/data/network/FakeLoginApiClient.kt
@@ -1,0 +1,17 @@
+package com.ikarimeister.loginapp.data.network
+
+import arrow.core.Either
+import arrow.core.right
+import com.ikarimeister.loginapp.data.LoginApiClient
+import com.ikarimeister.loginapp.data.network.dto.LoginResponse
+import com.ikarimeister.loginapp.data.network.dto.toDomain
+import com.ikarimeister.loginapp.domain.model.LoginError
+import com.ikarimeister.loginapp.domain.model.Token
+import com.ikarimeister.loginapp.domain.model.User
+
+object FakeLoginApiClient : LoginApiClient {
+    private const val DEFAULT_TOKEN_VALUE = "ñdslkfñldkfñs"
+
+    override fun login(user: User): Either<LoginError, Token> =
+            LoginResponse(DEFAULT_TOKEN_VALUE).toDomain().right()
+}

--- a/app/src/main/java/com/ikarimeister/loginapp/data/network/LoginService.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/data/network/LoginService.kt
@@ -1,0 +1,12 @@
+package com.ikarimeister.loginapp.data.network
+
+import com.ikarimeister.loginapp.data.network.dto.LoginRequest
+import com.ikarimeister.loginapp.data.network.dto.LoginResponse
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface LoginService {
+    @POST("login/")
+    fun login(@Body login: LoginRequest): Call<LoginResponse>
+}

--- a/app/src/main/java/com/ikarimeister/loginapp/data/network/RealLoginApiClient.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/data/network/RealLoginApiClient.kt
@@ -1,0 +1,46 @@
+package com.ikarimeister.loginapp.data.network
+
+import arrow.core.Either
+import arrow.core.left
+import com.ikarimeister.loginapp.data.LoginApiClient
+import com.ikarimeister.loginapp.data.network.dto.toDomain
+import com.ikarimeister.loginapp.data.network.dto.toDto
+import com.ikarimeister.loginapp.data.network.interceptor.DefaultHeadersInterceptor
+import com.ikarimeister.loginapp.domain.model.IncorrectCredentials
+import com.ikarimeister.loginapp.domain.model.LoginError
+import com.ikarimeister.loginapp.domain.model.NoConection
+import com.ikarimeister.loginapp.domain.model.Token
+import com.ikarimeister.loginapp.domain.model.User
+import java.io.IOException
+import okhttp3.OkHttpClient
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+class RealLoginApiClient(val baseEndpoint: String) : LoginApiClient {
+
+    private val service by lazy {
+        val client = OkHttpClient().newBuilder().addInterceptor(DefaultHeadersInterceptor()).build()
+        val retrofit = Retrofit.Builder()
+                .baseUrl(baseEndpoint)
+                .client(client)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+        retrofit.create(LoginService::class.java)
+    }
+
+    override fun login(user: User): Either<LoginError, Token> = try {
+        val response = service.login(user.toDto()).execute()
+        inspectResponseForErrors(response).map { it.toDomain() }
+    } catch (e: IOException) {
+        NoConection.left()
+    }
+
+    @Suppress("MagicNumber")
+    private fun <T> inspectResponseForErrors(response: Response<T>): Either<LoginError, T> = when {
+        response.code() == 403 -> IncorrectCredentials.left()
+        response.code() >= 400 -> NoConection.left()
+        response.body() == null -> IncorrectCredentials.left()
+        else -> Either.right((response.body()!!))
+    }
+}

--- a/app/src/main/java/com/ikarimeister/loginapp/data/network/dto/LoginRequest.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/data/network/dto/LoginRequest.kt
@@ -1,0 +1,10 @@
+package com.ikarimeister.loginapp.data.network.dto
+
+import com.ikarimeister.loginapp.domain.model.Email
+import com.ikarimeister.loginapp.domain.model.Password
+import com.ikarimeister.loginapp.domain.model.User
+
+data class LoginRequest(val username: Email, val password: Password)
+
+fun User.toDto() =
+        LoginRequest(username = this.email, password = this.password)

--- a/app/src/main/java/com/ikarimeister/loginapp/data/network/dto/LoginResponse.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/data/network/dto/LoginResponse.kt
@@ -1,0 +1,7 @@
+package com.ikarimeister.loginapp.data.network.dto
+
+import com.ikarimeister.loginapp.domain.model.Token
+
+data class LoginResponse(val token: String)
+
+fun LoginResponse.toDomain() = Token(this.token)

--- a/app/src/main/java/com/ikarimeister/loginapp/data/network/interceptor/DefaultHeadersInterceptor.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/data/network/interceptor/DefaultHeadersInterceptor.kt
@@ -1,0 +1,15 @@
+package com.ikarimeister.loginapp.data.network.interceptor
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class DefaultHeadersInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        var request = chain.request()
+        request = request.newBuilder()
+                .addHeader("Accept", "application/json")
+                .addHeader("Content-Type", "application/json")
+                .build()
+        return chain.proceed(request)
+    }
+}

--- a/app/src/main/java/com/ikarimeister/loginapp/domain/model/LoginError.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/domain/model/LoginError.kt
@@ -1,0 +1,6 @@
+package com.ikarimeister.loginapp.domain.model
+
+sealed class LoginError
+
+object NoConection : LoginError()
+object IncorrectCredentials : LoginError()

--- a/app/src/main/java/com/ikarimeister/loginapp/domain/model/User.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/domain/model/User.kt
@@ -1,0 +1,9 @@
+package com.ikarimeister.loginapp.domain.model
+
+data class User(val email: Email, val password: Password)
+
+inline class Email(val value: String)
+
+inline class Password(val value: String)
+
+inline class Token(val value: String)

--- a/app/src/main/java/com/ikarimeister/loginapp/domain/usecases/Login.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/domain/usecases/Login.kt
@@ -1,0 +1,17 @@
+package com.ikarimeister.loginapp.domain.usecases
+
+import arrow.core.Either
+import com.ikarimeister.loginapp.data.LoginApiClient
+import com.ikarimeister.loginapp.data.network.FakeLoginApiClient
+import com.ikarimeister.loginapp.domain.model.LoginError
+import com.ikarimeister.loginapp.domain.model.Token
+import com.ikarimeister.loginapp.domain.model.User
+
+class Login(private val apiClient: LoginApiClient = Dependencies.apiClient) {
+    operator fun invoke(user: User): Either<LoginError, Token> =
+            apiClient.login(user)
+
+    companion object Dependencies {
+        val apiClient = FakeLoginApiClient
+    }
+}

--- a/app/src/test/java/com/ikarimeister/loginapp/data/network/MockWebServerTest.kt
+++ b/app/src/test/java/com/ikarimeister/loginapp/data/network/MockWebServerTest.kt
@@ -1,0 +1,107 @@
+package com.ikarimeister.loginapp.data.network
+
+import java.io.File
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.apache.commons.io.FileUtils
+import org.hamcrest.MatcherAssert
+import org.hamcrest.core.StringContains
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+
+open class MockWebServerTest {
+
+    companion object {
+        private val FILE_ENCODING = "UTF-8"
+    }
+
+    private var server: MockWebServer = MockWebServer()
+
+    @Before
+    open fun setup() {
+        server.start()
+    }
+
+    @After
+    fun teardown() {
+        server.shutdown()
+    }
+
+    fun enqueueMockResponse(code: Int = 200, fileName: String? = null) {
+        val mockResponse = MockResponse()
+        val fileContent = getContentFromFile(fileName)
+        mockResponse.setResponseCode(code)
+        mockResponse.setBody(fileContent)
+        server.enqueue(mockResponse)
+    }
+
+    protected fun assertRequestSentTo(url: String) {
+        val request = server.takeRequest()
+        Assert.assertEquals(url, request.path)
+    }
+
+    protected fun assertGetRequestSentTo(url: String) {
+        val request = server.takeRequest()
+        Assert.assertEquals(url, request.path)
+        Assert.assertEquals("GET", request.method)
+    }
+
+    protected fun assertPostRequestSentTo(url: String) {
+        val request = server.takeRequest()
+        Assert.assertEquals(url, request.path)
+        Assert.assertEquals("POST", request.method)
+    }
+
+    protected fun assertPutRequestSentTo(url: String) {
+        val request = server.takeRequest()
+        Assert.assertEquals(url, request.path)
+        Assert.assertEquals("PUT", request.method)
+    }
+
+    protected fun assertDeleteRequestSentTo(url: String) {
+        val request = server.takeRequest()
+        Assert.assertEquals(url, request.path)
+        Assert.assertEquals("DELETE", request.method)
+    }
+
+    protected fun assertRequestSentToContains(vararg paths: String) {
+        val request = server.takeRequest()
+
+        for (path in paths) {
+            MatcherAssert.assertThat(request.path, StringContains.containsString(path))
+        }
+    }
+
+    fun assertRequestContainsHeader(key: String, expectedValue: String, requestIndex: Int = 0) {
+        val recordedRequest = getRecordedRequestAtIndex(requestIndex)
+        val value = recordedRequest!!.getHeader(key)
+        Assert.assertEquals(expectedValue, value)
+    }
+
+    protected val baseEndpoint: String
+        get() = server.url("/").toString()
+
+    protected fun assertRequestBodyEquals(jsonFile: String) {
+        val request = server.takeRequest()
+        Assert.assertEquals(getContentFromFile(jsonFile), request.body.readUtf8())
+    }
+
+    private fun getContentFromFile(fileName: String? = null): String {
+        return if (fileName == null) {
+            ""
+        } else {
+            val file = File(javaClass.getResource("/" + fileName).file)
+            val lines = FileUtils.readLines(file, FILE_ENCODING)
+            val stringBuilder = StringBuilder()
+            for (line in lines) {
+                stringBuilder.append(line)
+            }
+            stringBuilder.toString()
+        }
+    }
+
+    private fun getRecordedRequestAtIndex(requestIndex: Int): RecordedRequest? =
+            (0..requestIndex).map { server.takeRequest() }.last()
+}

--- a/app/src/test/java/com/ikarimeister/loginapp/data/network/RealLoginApiClientTest.kt
+++ b/app/src/test/java/com/ikarimeister/loginapp/data/network/RealLoginApiClientTest.kt
@@ -1,0 +1,81 @@
+package com.ikarimeister.loginapp.data.network
+
+import arrow.core.Either
+import com.ikarimeister.loginapp.data.LoginApiClient
+import com.ikarimeister.loginapp.domain.model.*
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class RealLoginApiClientTest : MockWebServerTest() {
+    private lateinit var apiClient: LoginApiClient
+
+    companion object {
+        val anyUser = User(email = Email("jcgseco@gmail.com"), password = Password("123456"))
+    }
+
+    @Before
+    override fun setup() {
+        super.setup()
+        val mockWebServerEndpoint = baseEndpoint
+        apiClient = RealLoginApiClient(mockWebServerEndpoint)
+    }
+
+    @Test
+    fun `sends Accept and ContentType headers`() {
+        enqueueMockResponse(403)
+
+        apiClient.login(anyUser)
+
+        assertRequestContainsHeader("Accept", "application/json")
+    }
+
+    @Test
+    fun `sends login to correct endpoint and correct Http method`() {
+        enqueueMockResponse(403)
+
+        apiClient.login(anyUser)
+
+        assertPostRequestSentTo("/login/")
+    }
+
+    @Test
+    fun `sends login correct body`() {
+        enqueueMockResponse(200, "login/response.json")
+
+        apiClient.login(anyUser)
+
+        assertRequestBodyEquals("login/request.json")
+    }
+
+    @Test
+    fun `Token Retrieved when success login response is received`() {
+        enqueueMockResponse(200, "login/response.json")
+        val expected = Token("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.")
+
+        val actual = apiClient.login(anyUser)
+
+        assert(actual is Either.Right<Token>)
+        actual.map { assertEquals(expected, it) }
+    }
+
+    @Test
+    fun `InvalidCredentials error when failure login response is received`() {
+        enqueueMockResponse(403)
+
+        val actual = apiClient.login(anyUser)
+
+        assert(actual is Either.Left<LoginError>)
+        actual.mapLeft { assertEquals(IncorrectCredentials, it) }
+    }
+
+    @Test
+    fun `NoConnection error when any other response is received`() {
+        enqueueMockResponse(500)
+
+        val actual = apiClient.login(anyUser)
+
+        assert(actual is Either.Left<LoginError>)
+        actual.mapLeft { assertEquals(NoConection, it) }
+    }
+}

--- a/app/src/test/java/com/ikarimeister/loginapp/domain/usecases/LoginTest.kt
+++ b/app/src/test/java/com/ikarimeister/loginapp/domain/usecases/LoginTest.kt
@@ -1,0 +1,49 @@
+package com.ikarimeister.loginapp.domain.usecases
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import com.ikarimeister.loginapp.data.LoginApiClient
+import com.ikarimeister.loginapp.domain.model.*
+import io.mockk.every
+import io.mockk.mockkClass
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class LoginTest {
+
+    private lateinit var stubApiClient: LoginApiClient
+    private lateinit var sut: Login
+
+    @Before
+    fun setup() {
+        stubApiClient = mockkClass(LoginApiClient::class)
+        sut = Login(stubApiClient)
+    }
+
+    @Test
+    fun `Should return a LoginError when LoginApiClient returns any login error`() {
+        every { stubApiClient.login(any()) } returns NoConection.left()
+        val user = User(email = Email(""), password = Password(""))
+
+        val actual = sut.invoke(user)
+
+        assertTrue(actual is Either.Left<LoginError>)
+    }
+
+    @Test
+    fun `Should return a Token when LoginApiClient returns a Token`() {
+        val token = Token("")
+        every { stubApiClient.login(any()) } returns token.right()
+        val user = User(email = Email(""), password = Password(""))
+
+        val actual = sut.invoke(user)
+
+        assertEquals(token.right(), actual)
+    }
+}

--- a/app/src/test/resources/login/request.json
+++ b/app/src/test/resources/login/request.json
@@ -1,0 +1,1 @@
+{"username":"jcgseco@gmail.com","password":"123456"}

--- a/app/src/test/resources/login/response.json
+++ b/app/src/test/resources/login/response.json
@@ -1,0 +1,1 @@
+{"token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."}

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,14 +1,18 @@
 ext {
     appcompat_version = "1.1.0"
     arrow_version="0.10.5"
+    commonsio_version = "2.6"
     constraintlayout_version = "1.1.3"
     corektx_version = "1.3.0"
     espresso_version = '3.2.0'
     espressorunner_version = '1.2.0'
     detekt_version = '1.7.0'
+    gson_version = '2.8.6'
     junit_version = '4.13'
     kotlin_version = '1.3.72'
     kotlintest_version = "2.0.7"
     ktlint_version = '0.34.2'
     mockk_version = "1.10.0"
+    mockwebserver_version = '4.4.0'
+    retrofit_version = '2.8.1'
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,5 +1,6 @@
 ext {
     appcompat_version = "1.1.0"
+    arrow_version="0.10.5"
     constraintlayout_version = "1.1.3"
     corektx_version = "1.3.0"
     espresso_version = '3.2.0'
@@ -7,5 +8,7 @@ ext {
     detekt_version = '1.7.0'
     junit_version = '4.13'
     kotlin_version = '1.3.72'
+    kotlintest_version = "2.0.7"
     ktlint_version = '0.34.2'
+    mockk_version = "1.10.0"
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #12 

### :tophat: What is the goal?

Call the API to login to the platform. The request will be like:

```json

{"username":"johndoe@company.com","password":"123456"}

```

The API should respond with:

* 200 -> OK with body 
```json
{"token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."}
```
* 403 -> KO

### :memo: How is it being implemented?

The API client pattern has been used to call the API, I've considered not to use Repository pattern because I'm implementing a Login and I think this pattern doesn't apply to this specific case. Since, at this time, there are two implementations of the API client I've decided to abstract them to an interface to replace them at will when the API will be ready.
Since the API is not ready a Fake implementation of the API client will be provided. As the contract of the API is already defined, We will implement also a Real ApiClient that will be tested using **HttpStubbing** with _MockWebServer_.
Even though the domain and data models are pretty similar right now, in fact, they are identical, I've decided to separate them as the API is not ready and contracts could be changed, also this is the first implementation of the domain layer and their models could be changed as well if other needs are detected in further tasks. Mapping extension functions are placed here to satisfy the dependency rule.

In the domain layer, I've used the command pattern to provide a simple access point to the feature from the presentation layer. The interactions and threading tools are not implemented yet.
The error hierarchy has been implemented through sealed class. For the User domain class inline classes has been used to type the String values.


Presentation and UI layers are not implemented yet.

I will use Arrow library to implement Either type and using it to simplify the callbacks.

### :boom: How can it be tested?

- [x] **Correct Credentials** When the API responds with a 200 and a valid response the Login use case returns and Either.Right with the token returned by the API.
- [x] **Incorrect Credentials:** When the API responds with a 403  the Login use case returns and Either.Left with the IncorrectCredentials Error.
- [x] **Any other error:** As far as no other kind of errors are already defined, any other answer of the API or an IOException will return an Either.Left with a NoConnection error.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!