### PR TITLE
Bugfix/download ci results

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Android CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:
@@ -22,4 +22,11 @@ jobs:
           ${{ runner.os }}-gradle-
 
     - name: Build with Gradle
-      run: ./gradlew test
+      run: ./gradlew assembleDebug
+
+    - uses: actions/upload-artifact@v2
+      name: binaries
+      with:
+        name: binary
+        path: |
+          ./app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -23,3 +23,10 @@ jobs:
 
       - name: Check code style ktlint and detekt
         run: ./gradlew check ktlint detekt
+
+      - uses: actions/upload-artifact@v2
+        name: checkstyle-reports
+        with:
+          name: checkstyle-reports
+          path: |
+            ./app/build/reports

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,4 @@
-name: Android Checkstyle
+name: Android Checkstyle & Unit Testing
 
 on: [push, pull_request]
 
@@ -22,11 +22,11 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Check code style ktlint and detekt
-        run: ./gradlew check ktlint detekt
+        run: ./gradlew check ktlint detekt testDebugUnitTest
 
       - uses: actions/upload-artifact@v2
-        name: checkstyle-reports
+        name: unit-test-reports
         with:
-          name: checkstyle-reports
+          name: unit-test-reports
           path: |
             ./app/build/reports

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Since the API is not ready a Fake implementation of the API client will be provi
 
 Several CI checks are set up yo guarantee code style and code quality standards are fulfilled.
 
-* **_Android Checkstyle_**: this GitHub Action will check the code style on every push and pull request by using **ktlint** and **detekt**
-* **_Android CI_**: this GitHub Action will run unit tests on every push and pull request.
+* **_Android Checkstyle and Unit Test_**: this GitHub Action will check the code style on every push and pull request by using **ktlint** and **detekt**. It also run Unit tests. The report can be found as an artifact for this action.
+* **_Android CI_**: this GitHub Action will assemble the debug binaries on every pull request. Those binaries can be found as binaries artifact on the action.
 * **_labeler_**: GitHub Action to check on pull request, the size of the pull request categorizing them in sizes according to the number of lines modified. It will fail if the pull request has more than 1000 lines modified.
 * **_Travis CI_**: TravisCI will be used on pull requests to run heavier tests, like UI tests, to not delay checks on pushes.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,11 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
+
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #4 #11 
* **Related pull-requests:** #8 

### :tophat: What is the goal?

I want to download the execution reports of CI service.

### :memo: How is it being implemented?

Using actions/upload-artifact@v2 
*  Checkstyle and Unit Testing action allows downloading as an artifact, linters and unit test reports.
* Android CI action now only runs on PR and allows downloading the generated debug apk as an artifact.

### :floppy_disk: Requires DB migration?

- [ ] Nope, we can just merge this branch.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!