### PR TITLE
Token storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ This repository contains an Android application that allows user to perform a lo
 
 ![UIpreview](docs/UIpreview.png) 
 
-Since the API is not ready a Fake implementation of the API client will be provided. As the contract of the API is already defined, We will implement also a Real ApiClient that will be tested using **HttpStubbing** with _MockWebServer_.
+Since the API is not ready a Fake implementation of the API client will be provided. As the contract of the API is already defined, We will implement also a Real ApiClient, using retrofit, that will be tested using **HttpStubbing** with _MockWebServer_.
+
+The local storage for the login information is implemented using a Repository pattern. With the requirements we already have, the data source we will use will be Android Shared Preferences since is a simple solution, but in the future could be replaced by a database implementation, to make this change easier we will use Repository pattern, to abstract the business logic from the real data source and allow to replace data source implementation fast and smooth.
+Since the data source is implemented with Shared Preferences over Android SDK, instrumentation tests will be required to test its correct working.
 
 ## CI
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,12 +13,15 @@ android {
         versionCode 1
         versionName "1.0"
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {
         sourceCompatibility 1.8
         targetCompatibility 1.8
+    }
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 
     buildTypes {
@@ -43,10 +46,19 @@ dependencies {
     implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
     implementation "com.google.code.gson:gson:$gson_version"
 
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     testImplementation "junit:junit:$junit_version"
     testImplementation "io.kotlintest:kotlintest:$kotlintest_version"
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "com.squareup.okhttp3:mockwebserver:$mockwebserver_version"
     testImplementation "commons-io:commons-io:$commonsio_version"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$espresso_version"
+    androidTestImplementation "androidx.test:runner:$espressorunner_version"
+    androidTestImplementation "androidx.test.ext:junit:1.1.1"
+    androidTestImplementation "androidx.test:rules:$espressorunner_version"
+    androidTestImplementation("com.schibsted.spain:barista:$barista_version") {
+        exclude group: 'org.jetbrains.kotlin' // Only if you already use Kotlin in your project
+    }
 
 }

--- a/app/src/androidTest/java/com/ikarimeister/loginapp/data/local/SharedPreferencesTokenDataSourceTest.kt
+++ b/app/src/androidTest/java/com/ikarimeister/loginapp/data/local/SharedPreferencesTokenDataSourceTest.kt
@@ -1,0 +1,103 @@
+package com.ikarimeister.loginapp.data.local
+
+import android.content.Context.MODE_PRIVATE
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import arrow.core.Either
+import com.ikarimeister.loginapp.asApp
+import com.ikarimeister.loginapp.domain.model.StorageError
+import com.ikarimeister.loginapp.domain.model.Token
+import com.ikarimeister.loginapp.domain.model.TokenNotFound
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+typealias ActualDS = SharedPreferencesTokenDataSource
+
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class SharedPreferencesTokenDataSourceTest {
+    private lateinit var dataSource: TokenDataSource
+    private lateinit var preferences: SharedPreferences
+
+    companion object {
+        const val ANY_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+    }
+
+    @Before
+    fun setUp() {
+        val app = InstrumentationRegistry.getInstrumentation().targetContext.asApp()
+        preferences = app.getSharedPreferences(ActualDS.ID, MODE_PRIVATE)
+        dataSource = ActualDS(preferences)
+    }
+
+    @After
+    fun tearDown() {
+        preferences.edit { clear() }
+    }
+
+    @Test
+    fun itemShouldBeOnSharedpreferencesWhenIAddItOnDatasource() {
+        val token = Token(ANY_TOKEN)
+
+        val result = dataSource + token
+
+        Assert.assertTrue(result is Either.Right<Unit>)
+        Assert.assertTrue(preferences.contains(ActualDS.ID))
+        val actual = preferences.getString(ActualDS.ID, "")!!
+        Assert.assertEquals(ANY_TOKEN, actual)
+    }
+
+    @Test
+    fun itemShouldBeOnSharedpreferencesWhenIAddItOnDatasourceEvenIfDatasourceWasNotEmpty() {
+        dataSource + Token("")
+        val token = Token(ANY_TOKEN)
+
+        val result = dataSource + token
+
+        Assert.assertTrue(result is Either.Right<Unit>)
+        Assert.assertTrue(preferences.contains(ActualDS.ID))
+        val actual = preferences.getString(ActualDS.ID, "")!!
+        Assert.assertEquals(ANY_TOKEN, actual)
+    }
+
+    @Test
+    fun itemIsReturnedByGetWhenIAddItOnDatasource() {
+        val token = Token(ANY_TOKEN)
+        dataSource + token
+
+        val actual = dataSource.get()
+
+        Assert.assertTrue(preferences.contains(ActualDS.ID))
+        Assert.assertTrue(actual is Either.Right<Token>)
+        actual.map { Assert.assertEquals(token, it) }
+    }
+
+    @Test
+    fun theTokenNotFoundErrorIsReturnedByGetWhenDatasourceIsEmpty() {
+        val actual = dataSource.get()
+
+        Assert.assertFalse(preferences.contains(ActualDS.ID))
+        Assert.assertTrue(actual is Either.Left<StorageError>)
+        actual.mapLeft { Assert.assertEquals(TokenNotFound, it) }
+    }
+
+    @Test
+    fun sharedPreferencesShouldBeEmptyWhenItemIsRemovedFromDataSource() {
+        val token = Token(ANY_TOKEN)
+        dataSource + token
+
+        val result = dataSource - token
+
+        Assert.assertTrue(result is Either.Right<Unit>)
+        Assert.assertFalse(preferences.contains(ActualDS.ID))
+        val actual = dataSource.get()
+        Assert.assertTrue(actual is Either.Left<StorageError>)
+        actual.mapLeft { Assert.assertEquals(TokenNotFound, it) }
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,11 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.ikarimeister.loginapp">
 
     <application
-            android:allowBackup="true"
-            android:label="@string/app_name"
-            android:icon="@mipmap/ic_launcher"
-            android:roundIcon="@mipmap/ic_launcher_round"
-            android:supportsRtl="true"
-            android:theme="@style/AppTheme"/>
+        android:name=".LoginApp"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme">
+        <activity android:name=".ui.activities.MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+    </application>
+
 </manifest>

--- a/app/src/main/java/com/ikarimeister/loginapp/LoginApp.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/LoginApp.kt
@@ -1,0 +1,19 @@
+package com.ikarimeister.loginapp
+
+import android.app.Application
+import android.content.Context
+
+class LoginApp : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        instance = this
+    }
+
+    companion object {
+        lateinit var instance: LoginApp
+            private set
+    }
+}
+
+fun Context.asApp(): LoginApp = this.applicationContext as LoginApp

--- a/app/src/main/java/com/ikarimeister/loginapp/data/TokenRepository.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/data/TokenRepository.kt
@@ -1,0 +1,13 @@
+package com.ikarimeister.loginapp.data
+
+import arrow.core.Either
+import com.ikarimeister.loginapp.data.local.TokenDataSource
+import com.ikarimeister.loginapp.domain.model.StorageError
+import com.ikarimeister.loginapp.domain.model.Token
+
+class TokenRepository(private val datasource: TokenDataSource) {
+
+    fun get(): Either<StorageError, Token> = datasource.get()
+    operator fun plus(element: Token): Either<StorageError, Unit> = datasource + element
+    operator fun minus(element: Token): Either<StorageError, Unit> = datasource - element
+}

--- a/app/src/main/java/com/ikarimeister/loginapp/data/local/SharedPreferencesTokenDataSource.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/data/local/SharedPreferencesTokenDataSource.kt
@@ -1,0 +1,36 @@
+package com.ikarimeister.loginapp.data.local
+
+import android.content.Context.MODE_PRIVATE
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import com.ikarimeister.loginapp.LoginApp
+import com.ikarimeister.loginapp.domain.model.StorageError
+import com.ikarimeister.loginapp.domain.model.Token
+import com.ikarimeister.loginapp.domain.model.TokenNotFound
+
+class SharedPreferencesTokenDataSource(
+    private val preferences: SharedPreferences = Companion.preferences
+) : TokenDataSource {
+    override fun get(): Either<StorageError, Token> =
+            if (preferences.contains(ID)) {
+                preferences.getString(ID, null)
+                        ?.right()?.map { Token(it) }
+                        ?: TokenNotFound.left()
+            } else {
+                TokenNotFound.left()
+            }
+
+    override fun plus(element: Token): Either<StorageError, Unit> =
+            preferences.edit { putString(ID, element.value) }.right()
+
+    override fun minus(element: Token): Either<StorageError, Unit> =
+            preferences.edit { remove(ID) }.right()
+
+    companion object {
+        const val ID = "token"
+        val preferences: SharedPreferences = LoginApp.instance.getSharedPreferences(ID, MODE_PRIVATE)!!
+    }
+}

--- a/app/src/main/java/com/ikarimeister/loginapp/data/local/TokenDataSource.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/data/local/TokenDataSource.kt
@@ -1,0 +1,11 @@
+package com.ikarimeister.loginapp.data.local
+
+import arrow.core.Either
+import com.ikarimeister.loginapp.domain.model.StorageError
+import com.ikarimeister.loginapp.domain.model.Token
+
+interface TokenDataSource {
+    fun get(): Either<StorageError, Token>
+    operator fun plus(element: Token): Either<StorageError, Unit>
+    operator fun minus(element: Token): Either<StorageError, Unit>
+}

--- a/app/src/main/java/com/ikarimeister/loginapp/domain/model/StorageError.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/domain/model/StorageError.kt
@@ -1,0 +1,5 @@
+package com.ikarimeister.loginapp.domain.model
+
+sealed class StorageError
+object TokenNotFound : StorageError()
+data class UnknownStorageError(val t: Throwable) : StorageError()

--- a/app/src/main/java/com/ikarimeister/loginapp/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/ui/activities/MainActivity.kt
@@ -1,0 +1,13 @@
+package com.ikarimeister.loginapp.ui.activities
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.ikarimeister.loginapp.R
+
+class MainActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.activities.MainActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/test/java/com/ikarimeister/loginapp/data/TokenRepositoryTest.kt
+++ b/app/src/test/java/com/ikarimeister/loginapp/data/TokenRepositoryTest.kt
@@ -1,0 +1,57 @@
+package com.ikarimeister.loginapp.data
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import com.ikarimeister.loginapp.data.local.TokenDataSource
+import com.ikarimeister.loginapp.domain.model.StorageError
+import com.ikarimeister.loginapp.domain.model.Token
+import com.ikarimeister.loginapp.domain.model.TokenNotFound
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class TokenRepositoryTest {
+
+    companion object {
+        const val ANY_TOKEN = "fdgfdgfdgfdhfghdf"
+    }
+
+    lateinit var repository: TokenRepository
+
+    @MockK
+    lateinit var dataSource: TokenDataSource
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        repository = TokenRepository(dataSource)
+    }
+
+    @Test
+    fun `Token is returned from datasource when datasource has a token`() {
+        val token = Token(ANY_TOKEN)
+        every { dataSource.get() } returns token.right()
+
+        val actual = repository.get()
+
+        assertTrue(actual is Either.Right<Token>)
+        verify { dataSource.get() }
+        actual.map { assertEquals(token, it) }
+    }
+
+    @Test
+    fun `TokenNotFound is returned from datasource when datasource has no token`() {
+        every { dataSource.get() } returns TokenNotFound.left()
+
+        val actual = repository.get()
+
+        assertTrue(actual is Either.Left<StorageError>)
+        actual.mapLeft { assertEquals(TokenNotFound, it) }
+    }
+}

--- a/app/src/test/java/com/ikarimeister/loginapp/data/network/RealLoginApiClientTest.kt
+++ b/app/src/test/java/com/ikarimeister/loginapp/data/network/RealLoginApiClientTest.kt
@@ -12,6 +12,7 @@ class RealLoginApiClientTest : MockWebServerTest() {
 
     companion object {
         val anyUser = User(email = Email("jcgseco@gmail.com"), password = Password("123456"))
+        const val ANY_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
     }
 
     @Before
@@ -51,7 +52,7 @@ class RealLoginApiClientTest : MockWebServerTest() {
     @Test
     fun `Token Retrieved when success login response is received`() {
         enqueueMockResponse(200, "login/response.json")
-        val expected = Token("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.")
+        val expected = Token(ANY_TOKEN)
 
         val actual = apiClient.login(anyUser)
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,9 +1,10 @@
 ext {
     appcompat_version = "1.1.0"
     arrow_version="0.10.5"
+    barista_version = '3.2.0'
     commonsio_version = "2.6"
     constraintlayout_version = "1.1.3"
-    corektx_version = "1.3.0"
+    corektx_version = "1.3.1"
     espresso_version = '3.2.0'
     espressorunner_version = '1.2.0'
     detekt_version = '1.7.0'


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #10, #13, #18 

### :tophat: What is the goal?

Create a token repository and token storage to save login token among app executions.

### :memo: How is it being implemented?

The local storage for the login information is implemented using a Repository pattern. With the requirements we already have, the data source we will use will be Android Shared Preferences since is a simple solution, but in the future could be replaced by a database implementation, to make this change easier we will use Repository pattern, to abstract the business logic from the real data source and allow to replace data source implementation fast and smooth.
Since the data source is implemented with Shared Preferences over Android SDK, instrumentation tests will be required to test its correct working.

The first screen has been added empty.

### :boom: How can it be tested?

- [x] **Use case 1:** Add a token to the repository, it will be available on shared preferences
- [x] **Use case 2:** Remove a token from the repository, previously added, it won¡t be available on shared preferences.
- [x] **Use case 3:** Try to retrieve a token, previously added, from the repository. Token will be retrieved.
- [x] **Use case 3:** Try to retrieve a token over an empty repository. Token won't be retrieved and error will be retrieved instead.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.

### :art: UI changes?

- [x] Yeap, here you have some screenshots-
![device-2020-07-22-224422](https://user-images.githubusercontent.com/19489766/88226805-ee9ca900-cc6c-11ea-9ef0-d1a873ae469a.png)
