### PR TITLE
Login usecase

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Since the API is not ready a Fake implementation of the API client will be provi
 The local storage for the login information is implemented using a Repository pattern. With the requirements we already have, the data source we will use will be Android Shared Preferences since is a simple solution, but in the future could be replaced by a database implementation, to make this change easier we will use Repository pattern, to abstract the business logic from the real data source and allow to replace data source implementation fast and smooth.
 Since the data source is implemented with Shared Preferences over Android SDK, instrumentation tests will be required to test its correct working.
 
+For the domain layer, Command pattern has been used as use cases. They are responsible to execute all business logic.
+
+For the threading problem, kotlinx.Coroutines are the solution chosen as Interactors since they are a fancy and most common way to implement the Interactors nowadays.
+
+For the presentation layer, MVP pattern is the chosen implementation because is the most familiar implementation for the development team, we could consider moving to MVVM with data binding, but our expertise and confidence with MVP make us feel more comfortable. 
+
 ## CI
 
 Several CI checks are set up yo guarantee code style and code quality standards are fulfilled.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
 
     implementation "io.arrow-kt:arrow-core-data:$arrow_version"
+    implementation "io.arrow-kt:arrow-fx:$arrow_version"
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
     implementation "com.google.code.gson:gson:$gson_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,20 +40,20 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.core:core-ktx:$corektx_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
-
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     implementation "io.arrow-kt:arrow-core-data:$arrow_version"
     implementation "io.arrow-kt:arrow-fx:$arrow_version"
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
     implementation "com.google.code.gson:gson:$gson_version"
 
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     testImplementation "junit:junit:$junit_version"
     testImplementation "io.kotlintest:kotlintest:$kotlintest_version"
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "com.squareup.okhttp3:mockwebserver:$mockwebserver_version"
     testImplementation "commons-io:commons-io:$commonsio_version"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espresso_version"
     androidTestImplementation "androidx.test:runner:$espressorunner_version"
     androidTestImplementation "androidx.test.ext:junit:1.1.1"

--- a/app/src/main/java/com/ikarimeister/loginapp/data/TokenRepository.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/data/TokenRepository.kt
@@ -1,13 +1,18 @@
 package com.ikarimeister.loginapp.data
 
 import arrow.core.Either
+import com.ikarimeister.loginapp.data.local.SharedPreferencesTokenDataSource
 import com.ikarimeister.loginapp.data.local.TokenDataSource
 import com.ikarimeister.loginapp.domain.model.StorageError
 import com.ikarimeister.loginapp.domain.model.Token
 
-class TokenRepository(private val datasource: TokenDataSource) {
+class TokenRepository(private val datasource: TokenDataSource = Companion.datasource) {
 
     fun get(): Either<StorageError, Token> = datasource.get()
     operator fun plus(element: Token): Either<StorageError, Unit> = datasource + element
     operator fun minus(element: Token): Either<StorageError, Unit> = datasource - element
+
+    companion object {
+        val datasource by lazy { SharedPreferencesTokenDataSource() }
+    }
 }

--- a/app/src/main/java/com/ikarimeister/loginapp/data/local/SharedPreferencesTokenDataSource.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/data/local/SharedPreferencesTokenDataSource.kt
@@ -31,6 +31,6 @@ class SharedPreferencesTokenDataSource(
 
     companion object {
         const val ID = "token"
-        val preferences: SharedPreferences = LoginApp.instance.getSharedPreferences(ID, MODE_PRIVATE)!!
+        val preferences: SharedPreferences by lazy { LoginApp.instance.getSharedPreferences(ID, MODE_PRIVATE)!! }
     }
 }

--- a/app/src/main/java/com/ikarimeister/loginapp/domain/usecases/Login.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/domain/usecases/Login.kt
@@ -1,17 +1,26 @@
 package com.ikarimeister.loginapp.domain.usecases
 
 import arrow.core.Either
+import arrow.core.extensions.fx
 import com.ikarimeister.loginapp.data.LoginApiClient
+import com.ikarimeister.loginapp.data.TokenRepository
 import com.ikarimeister.loginapp.data.network.FakeLoginApiClient
 import com.ikarimeister.loginapp.domain.model.LoginError
 import com.ikarimeister.loginapp.domain.model.Token
 import com.ikarimeister.loginapp.domain.model.User
 
-class Login(private val apiClient: LoginApiClient = Dependencies.apiClient) {
-    operator fun invoke(user: User): Either<LoginError, Token> =
-            apiClient.login(user)
+class Login(
+    private val apiClient: LoginApiClient = Companion.apiClient,
+    private val repository: TokenRepository = Companion.repository
+) {
+    operator fun invoke(user: User): Either<LoginError, Token> = Either.fx {
+        val token = apiClient.login(user).bind()
+        repository + token
+        token
+    }
 
-    companion object Dependencies {
-        val apiClient = FakeLoginApiClient
+    companion object {
+        val apiClient by lazy { FakeLoginApiClient }
+        val repository by lazy { TokenRepository() }
     }
 }

--- a/app/src/main/java/com/ikarimeister/loginapp/domain/usecases/Login.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/domain/usecases/Login.kt
@@ -13,7 +13,7 @@ class Login(
     private val apiClient: LoginApiClient = Companion.apiClient,
     private val repository: TokenRepository = Companion.repository
 ) {
-    operator fun invoke(user: User): Either<LoginError, Token> = Either.fx {
+    suspend operator fun invoke(user: User): Either<LoginError, Token> = Either.fx {
         val token = apiClient.login(user).bind()
         repository + token
         token

--- a/app/src/main/java/com/ikarimeister/loginapp/ui/coomons/Scope.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/ui/coomons/Scope.kt
@@ -1,0 +1,28 @@
+package com.ikarimeister.loginapp.ui.coomons
+
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+
+interface Scope : CoroutineScope {
+
+    class Impl(override val uiDispatcher: CoroutineDispatcher) : Scope {
+        override lateinit var job: Job
+    }
+
+    var job: Job
+    val uiDispatcher: CoroutineDispatcher
+
+    override val coroutineContext: CoroutineContext
+        get() = uiDispatcher + job
+
+    fun initScope() {
+        job = SupervisorJob()
+    }
+
+    fun destroyScope() {
+        job.cancel()
+    }
+}

--- a/app/src/main/java/com/ikarimeister/loginapp/ui/presenter/LoginPresenter.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/ui/presenter/LoginPresenter.kt
@@ -1,0 +1,31 @@
+package com.ikarimeister.loginapp.ui.presenter
+
+import com.ikarimeister.loginapp.domain.model.Email
+import com.ikarimeister.loginapp.domain.model.Password
+import com.ikarimeister.loginapp.domain.model.User
+import com.ikarimeister.loginapp.domain.usecases.Login
+import com.ikarimeister.loginapp.ui.coomons.Scope
+import com.ikarimeister.loginapp.ui.view.LoginView
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class LoginPresenter(
+    private val view: LoginView?,
+    private val login: Login,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    iuDispacher: CoroutineDispatcher = Dispatchers.Main
+) : Scope by Scope.Impl(iuDispacher) {
+
+    fun doLogin(email: Email, password: Password) = launch {
+        view?.showLoading()
+        val user = User(email, password)
+        val login = withContext(ioDispatcher) { login(user) }
+        view?.hideLoading()
+        login.fold(
+                { view?.showLoginError(it) },
+                { view?.navigateToLoggedScreen() }
+        )
+    }
+}

--- a/app/src/main/java/com/ikarimeister/loginapp/ui/view/LoginView.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/ui/view/LoginView.kt
@@ -1,0 +1,10 @@
+package com.ikarimeister.loginapp.ui.view
+
+import com.ikarimeister.loginapp.domain.model.LoginError
+
+interface LoginView {
+    fun showLoading()
+    fun hideLoading()
+    fun showLoginError(error: LoginError)
+    fun navigateToLoggedScreen()
+}

--- a/app/src/test/java/com/ikarimeister/loginapp/data/network/RealLoginApiClientTest.kt
+++ b/app/src/test/java/com/ikarimeister/loginapp/data/network/RealLoginApiClientTest.kt
@@ -11,7 +11,7 @@ class RealLoginApiClientTest : MockWebServerTest() {
     private lateinit var apiClient: LoginApiClient
 
     companion object {
-        val anyUser = User(email = Email("jcgseco@gmail.com"), password = Password("123456"))
+        val anyUser = User(email = Email("john.doe@company.com"), password = Password("123456"))
         const val ANY_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
     }
 

--- a/app/src/test/java/com/ikarimeister/loginapp/domain/usecases/LoginTest.kt
+++ b/app/src/test/java/com/ikarimeister/loginapp/domain/usecases/LoginTest.kt
@@ -10,6 +10,7 @@ import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockkClass
 import io.mockk.verify
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -32,9 +33,8 @@ class LoginTest {
     }
 
     @Test
-    fun `Should return a LoginError when LoginApiClient returns any login error`() {
+    fun `Should return a LoginError when LoginApiClient returns any login error`() = runBlocking {
         every { stubApiClient.login(any()) } returns NoConection.left()
-        val user = User(email = Email(""), password = Password(""))
 
         val actual = sut.invoke(user)
 
@@ -42,11 +42,9 @@ class LoginTest {
     }
 
     @Test
-    fun `Should return a Token when LoginApiClient returns a Token`() {
-        val token = Token("")
+    fun `Should return a Token when LoginApiClient returns a Token`() = runBlocking {
         every { stubApiClient.login(any()) } returns token.right()
         every { mockRepository.plus(token) } returns Unit.right()
-        val user = User(email = Email(""), password = Password(""))
 
         val actual = sut.invoke(user)
 
@@ -54,9 +52,8 @@ class LoginTest {
     }
 
     @Test
-    fun `Should save nothing on the repository when LoginApiClient returns any login error`() {
+    fun `Should save nothing on the repository when LoginApiClient returns any login error`() = runBlocking {
         every { stubApiClient.login(any()) } returns NoConection.left()
-        val user = User(email = Email(""), password = Password(""))
 
         sut.invoke(user)
 
@@ -64,14 +61,19 @@ class LoginTest {
     }
 
     @Test
-    fun `Should save on repository a Token when LoginApiClient returns a Token`() {
-        val token = Token("")
+    fun `Should save on repository a Token when LoginApiClient returns a Token`() = runBlocking {
         every { stubApiClient.login(any()) } returns token.right()
         every { mockRepository.plus(token) } returns Unit.right()
-        val user = User(email = Email(""), password = Password(""))
 
         sut.invoke(user)
 
         verify { mockRepository + token }
+    }
+
+    companion object {
+        private val email = Email("john.doe@company.com")
+        private val password = Password("123456")
+        private val token = Token("fdskjflsdjflsdjf")
+        private val user = User(email, password)
     }
 }

--- a/app/src/test/java/com/ikarimeister/loginapp/ui/presenter/LoginPresenterTest.kt
+++ b/app/src/test/java/com/ikarimeister/loginapp/ui/presenter/LoginPresenterTest.kt
@@ -1,0 +1,80 @@
+package com.ikarimeister.loginapp.ui.presenter
+
+import arrow.core.left
+import arrow.core.right
+import com.ikarimeister.loginapp.domain.model.*
+import com.ikarimeister.loginapp.domain.usecases.Login
+import com.ikarimeister.loginapp.ui.view.LoginView
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verifyOrder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class LoginPresenterTest {
+
+    @MockK
+    lateinit var login: Login
+
+    @MockK
+    lateinit var view: LoginView
+    private lateinit var presenter: LoginPresenter
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        presenter = LoginPresenter(view, login, Dispatchers.Unconfined, Dispatchers.Unconfined)
+        presenter.initScope()
+    }
+
+    @After
+    fun tearDown() {
+        presenter.destroyScope()
+    }
+
+    @Test
+    fun `View should show and hide loading and show an error when Login return error`() {
+        givenAView()
+        every { runBlocking { login(any()) } } returns IncorrectCredentials.left()
+
+        presenter.doLogin(email, password)
+
+        verifyOrder {
+            view.showLoading()
+            view.hideLoading()
+            view.showLoginError(IncorrectCredentials)
+        }
+    }
+
+    @Test
+    fun `View should show and hide loading and navigate to logged screen when Login return OK`() {
+        givenAView()
+        every { runBlocking { login(any()) } } returns token.right()
+
+        presenter.doLogin(email, password)
+
+        verifyOrder {
+            view.showLoading()
+            view.hideLoading()
+            view.navigateToLoggedScreen()
+        }
+    }
+
+    private fun givenAView() {
+        every { view.showLoading() } returns Unit
+        every { view.hideLoading() } returns Unit
+        every { view.showLoginError(any()) } returns Unit
+        every { view.navigateToLoggedScreen() } returns Unit
+    }
+
+    companion object {
+        private val email = Email("john.doe@company.com")
+        private val password = Password("123456")
+        private val token = Token("fdskjflsdjflsdjf")
+        private val user = User(email, password)
+    }
+}

--- a/app/src/test/resources/login/request.json
+++ b/app/src/test/resources/login/request.json
@@ -1,1 +1,1 @@
-{"username":"jcgseco@gmail.com","password":"123456"}
+{"username":"john.doe@company.com","password":"123456"}

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -5,6 +5,7 @@ ext {
     commonsio_version = "2.6"
     constraintlayout_version = "1.1.3"
     corektx_version = "1.3.1"
+    coroutines_version = '1.3.5'
     espresso_version = '3.2.0'
     espressorunner_version = '1.2.0'
     detekt_version = '1.7.0'


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #10 #19 

### :tophat: What is the goal?

Implement the logic to do login into the platform. When a validated user is received the API will be called via API client. If the API call is a success, the login token will be stored in Token storage, if not an error will be shown to the user.

### :memo: How is it being implemented?

Arrow fx library has been added to simplify Login use case logic. When the login API call is successful, the resulting token is stored on the token repository.

Plus that presentation layer has been added by using MVP pattern, with that also coroutines have been added as interactors.

### :boom: How can it be tested?

- [x] **Login Success**: Token is stored in the repository and view navigates to the logged screen.
- [x] **Login Failure:** view shows a login error message and the repository remains untouched.
### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!