### PR TITLE
Initial login

### DIFF
--- a/app/src/main/java/com/ikarimeister/loginapp/domain/usecases/IsLoginStored.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/domain/usecases/IsLoginStored.kt
@@ -1,0 +1,11 @@
+package com.ikarimeister.loginapp.domain.usecases
+
+import com.ikarimeister.loginapp.data.TokenRepository
+
+class IsLoginStored(private val repository: TokenRepository = Companion.repository) {
+    suspend operator fun invoke() = repository.get()
+
+    companion object {
+        val repository: TokenRepository by lazy { TokenRepository() }
+    }
+}

--- a/app/src/main/java/com/ikarimeister/loginapp/ui/presenter/LoginPresenter.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/ui/presenter/LoginPresenter.kt
@@ -3,6 +3,7 @@ package com.ikarimeister.loginapp.ui.presenter
 import com.ikarimeister.loginapp.domain.model.Email
 import com.ikarimeister.loginapp.domain.model.Password
 import com.ikarimeister.loginapp.domain.model.User
+import com.ikarimeister.loginapp.domain.usecases.IsLoginStored
 import com.ikarimeister.loginapp.domain.usecases.Login
 import com.ikarimeister.loginapp.ui.coomons.Scope
 import com.ikarimeister.loginapp.ui.view.LoginView
@@ -14,6 +15,7 @@ import kotlinx.coroutines.withContext
 class LoginPresenter(
     private val view: LoginView?,
     private val login: Login,
+    private val isLoginStored: IsLoginStored,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     iuDispacher: CoroutineDispatcher = Dispatchers.Main
 ) : Scope by Scope.Impl(iuDispacher) {
@@ -25,6 +27,16 @@ class LoginPresenter(
         view?.hideLoading()
         login.fold(
                 { view?.showLoginError(it) },
+                { view?.navigateToLoggedScreen() }
+        )
+    }
+
+    fun onStart() = launch {
+        view?.showLoading()
+        val isLogged = withContext(ioDispatcher) { isLoginStored() }
+        view?.hideLoading()
+        isLogged.fold(
+                { view?.showLoginForm() },
                 { view?.navigateToLoggedScreen() }
         )
     }

--- a/app/src/main/java/com/ikarimeister/loginapp/ui/view/LoginView.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/ui/view/LoginView.kt
@@ -7,4 +7,5 @@ interface LoginView {
     fun hideLoading()
     fun showLoginError(error: LoginError)
     fun navigateToLoggedScreen()
+    fun showLoginForm()
 }

--- a/app/src/test/java/com/ikarimeister/loginapp/data/TokenRepositoryTest.kt
+++ b/app/src/test/java/com/ikarimeister/loginapp/data/TokenRepositoryTest.kt
@@ -7,6 +7,7 @@ import com.ikarimeister.loginapp.data.local.TokenDataSource
 import com.ikarimeister.loginapp.domain.model.StorageError
 import com.ikarimeister.loginapp.domain.model.Token
 import com.ikarimeister.loginapp.domain.model.TokenNotFound
+import com.ikarimeister.loginapp.utils.MotherObject.token
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -18,11 +19,7 @@ import org.junit.Test
 
 class TokenRepositoryTest {
 
-    companion object {
-        const val ANY_TOKEN = "fdgfdgfdgfdhfghdf"
-    }
-
-    lateinit var repository: TokenRepository
+    private lateinit var repository: TokenRepository
 
     @MockK
     lateinit var dataSource: TokenDataSource
@@ -35,7 +32,6 @@ class TokenRepositoryTest {
 
     @Test
     fun `Token is returned from datasource when datasource has a token`() {
-        val token = Token(ANY_TOKEN)
         every { dataSource.get() } returns token.right()
 
         val actual = repository.get()

--- a/app/src/test/java/com/ikarimeister/loginapp/data/network/RealLoginApiClientTest.kt
+++ b/app/src/test/java/com/ikarimeister/loginapp/data/network/RealLoginApiClientTest.kt
@@ -3,17 +3,14 @@ package com.ikarimeister.loginapp.data.network
 import arrow.core.Either
 import com.ikarimeister.loginapp.data.LoginApiClient
 import com.ikarimeister.loginapp.domain.model.*
+import com.ikarimeister.loginapp.utils.MotherObject.ANY_TOKEN
+import com.ikarimeister.loginapp.utils.MotherObject.user
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
 class RealLoginApiClientTest : MockWebServerTest() {
     private lateinit var apiClient: LoginApiClient
-
-    companion object {
-        val anyUser = User(email = Email("john.doe@company.com"), password = Password("123456"))
-        const val ANY_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
-    }
 
     @Before
     override fun setup() {
@@ -26,7 +23,7 @@ class RealLoginApiClientTest : MockWebServerTest() {
     fun `sends Accept and ContentType headers`() {
         enqueueMockResponse(403)
 
-        apiClient.login(anyUser)
+        apiClient.login(user)
 
         assertRequestContainsHeader("Accept", "application/json")
     }
@@ -35,7 +32,7 @@ class RealLoginApiClientTest : MockWebServerTest() {
     fun `sends login to correct endpoint and correct Http method`() {
         enqueueMockResponse(403)
 
-        apiClient.login(anyUser)
+        apiClient.login(user)
 
         assertPostRequestSentTo("/login/")
     }
@@ -44,7 +41,7 @@ class RealLoginApiClientTest : MockWebServerTest() {
     fun `sends login correct body`() {
         enqueueMockResponse(200, "login/response.json")
 
-        apiClient.login(anyUser)
+        apiClient.login(user)
 
         assertRequestBodyEquals("login/request.json")
     }
@@ -54,7 +51,7 @@ class RealLoginApiClientTest : MockWebServerTest() {
         enqueueMockResponse(200, "login/response.json")
         val expected = Token(ANY_TOKEN)
 
-        val actual = apiClient.login(anyUser)
+        val actual = apiClient.login(user)
 
         assert(actual is Either.Right<Token>)
         actual.map { assertEquals(expected, it) }
@@ -64,7 +61,7 @@ class RealLoginApiClientTest : MockWebServerTest() {
     fun `InvalidCredentials error when failure login response is received`() {
         enqueueMockResponse(403)
 
-        val actual = apiClient.login(anyUser)
+        val actual = apiClient.login(user)
 
         assert(actual is Either.Left<LoginError>)
         actual.mapLeft { assertEquals(IncorrectCredentials, it) }
@@ -74,7 +71,7 @@ class RealLoginApiClientTest : MockWebServerTest() {
     fun `NoConnection error when any other response is received`() {
         enqueueMockResponse(500)
 
-        val actual = apiClient.login(anyUser)
+        val actual = apiClient.login(user)
 
         assert(actual is Either.Left<LoginError>)
         actual.mapLeft { assertEquals(NoConection, it) }

--- a/app/src/test/java/com/ikarimeister/loginapp/domain/usecases/IsLoginStoredTest.kt
+++ b/app/src/test/java/com/ikarimeister/loginapp/domain/usecases/IsLoginStoredTest.kt
@@ -7,6 +7,7 @@ import com.ikarimeister.loginapp.data.TokenRepository
 import com.ikarimeister.loginapp.domain.model.StorageError
 import com.ikarimeister.loginapp.domain.model.Token
 import com.ikarimeister.loginapp.domain.model.TokenNotFound
+import com.ikarimeister.loginapp.utils.MotherObject.token
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -45,9 +46,5 @@ class IsLoginStoredTest {
 
         Assert.assertTrue(actual is Either.Right<Token>)
         actual.map { Assert.assertEquals(token, it) }
-    }
-
-    companion object {
-        val token = Token("fkdsfjlsdfjlsfjk")
     }
 }

--- a/app/src/test/java/com/ikarimeister/loginapp/domain/usecases/IsLoginStoredTest.kt
+++ b/app/src/test/java/com/ikarimeister/loginapp/domain/usecases/IsLoginStoredTest.kt
@@ -1,0 +1,53 @@
+package com.ikarimeister.loginapp.domain.usecases
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import com.ikarimeister.loginapp.data.TokenRepository
+import com.ikarimeister.loginapp.domain.model.StorageError
+import com.ikarimeister.loginapp.domain.model.Token
+import com.ikarimeister.loginapp.domain.model.TokenNotFound
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class IsLoginStoredTest {
+
+    @MockK
+    lateinit var repository: TokenRepository
+    private lateinit var sut: IsLoginStored
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        sut = IsLoginStored(repository)
+    }
+
+    @Test
+    fun `should return a TokenNotFound error when repository is empty`() = runBlockingTest {
+        every { repository.get() } returns TokenNotFound.left()
+
+        val actual = sut()
+
+        Assert.assertTrue(actual is Either.Left<StorageError>)
+        actual.mapLeft { Assert.assertEquals(TokenNotFound, it) }
+    }
+
+    @Test
+    fun `should return a Token when repository has the token`() = runBlockingTest {
+        every { repository.get() } returns token.right()
+
+        val actual = sut()
+
+        Assert.assertTrue(actual is Either.Right<Token>)
+        actual.map { Assert.assertEquals(token, it) }
+    }
+
+    companion object {
+        val token = Token("fkdsfjlsdfjlsfjk")
+    }
+}

--- a/app/src/test/java/com/ikarimeister/loginapp/domain/usecases/LoginTest.kt
+++ b/app/src/test/java/com/ikarimeister/loginapp/domain/usecases/LoginTest.kt
@@ -6,6 +6,7 @@ import arrow.core.right
 import com.ikarimeister.loginapp.data.LoginApiClient
 import com.ikarimeister.loginapp.data.TokenRepository
 import com.ikarimeister.loginapp.domain.model.*
+import com.ikarimeister.loginapp.utils.MotherObject
 import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockkClass
@@ -36,44 +37,37 @@ class LoginTest {
     fun `Should return a LoginError when LoginApiClient returns any login error`() = runBlocking {
         every { stubApiClient.login(any()) } returns NoConection.left()
 
-        val actual = sut.invoke(user)
+        val actual = sut.invoke(MotherObject.user)
 
         assertTrue(actual is Either.Left<LoginError>)
     }
 
     @Test
     fun `Should return a Token when LoginApiClient returns a Token`() = runBlocking {
-        every { stubApiClient.login(any()) } returns token.right()
-        every { mockRepository.plus(token) } returns Unit.right()
+        every { stubApiClient.login(any()) } returns MotherObject.token.right()
+        every { mockRepository.plus(MotherObject.token) } returns Unit.right()
 
-        val actual = sut.invoke(user)
+        val actual = sut.invoke(MotherObject.user)
 
-        assertEquals(token.right(), actual)
+        assertEquals(MotherObject.token.right(), actual)
     }
 
     @Test
     fun `Should save nothing on the repository when LoginApiClient returns any login error`() = runBlocking {
         every { stubApiClient.login(any()) } returns NoConection.left()
 
-        sut.invoke(user)
+        sut.invoke(MotherObject.user)
 
         verify { mockRepository wasNot Called }
     }
 
     @Test
     fun `Should save on repository a Token when LoginApiClient returns a Token`() = runBlocking {
-        every { stubApiClient.login(any()) } returns token.right()
-        every { mockRepository.plus(token) } returns Unit.right()
+        every { stubApiClient.login(any()) } returns MotherObject.token.right()
+        every { mockRepository.plus(MotherObject.token) } returns Unit.right()
 
-        sut.invoke(user)
+        sut.invoke(MotherObject.user)
 
-        verify { mockRepository + token }
-    }
-
-    companion object {
-        private val email = Email("john.doe@company.com")
-        private val password = Password("123456")
-        private val token = Token("fdskjflsdjflsdjf")
-        private val user = User(email, password)
+        verify { mockRepository + MotherObject.token }
     }
 }

--- a/app/src/test/java/com/ikarimeister/loginapp/ui/presenter/LoginPresenterTest.kt
+++ b/app/src/test/java/com/ikarimeister/loginapp/ui/presenter/LoginPresenterTest.kt
@@ -3,6 +3,7 @@ package com.ikarimeister.loginapp.ui.presenter
 import arrow.core.left
 import arrow.core.right
 import com.ikarimeister.loginapp.domain.model.*
+import com.ikarimeister.loginapp.domain.usecases.IsLoginStored
 import com.ikarimeister.loginapp.domain.usecases.Login
 import com.ikarimeister.loginapp.ui.view.LoginView
 import io.mockk.MockKAnnotations
@@ -21,13 +22,16 @@ class LoginPresenterTest {
     lateinit var login: Login
 
     @MockK
+    lateinit var islogged: IsLoginStored
+
+    @MockK
     lateinit var view: LoginView
     private lateinit var presenter: LoginPresenter
 
     @Before
     fun setUp() {
         MockKAnnotations.init(this)
-        presenter = LoginPresenter(view, login, Dispatchers.Unconfined, Dispatchers.Unconfined)
+        presenter = LoginPresenter(view, login, islogged, Dispatchers.Unconfined, Dispatchers.Unconfined)
         presenter.initScope()
     }
 
@@ -61,6 +65,34 @@ class LoginPresenterTest {
             view.showLoading()
             view.hideLoading()
             view.navigateToLoggedScreen()
+        }
+    }
+
+    @Test
+    fun `View should show and hide loading and navigate to logged screen when starts and a Token is stored`() {
+        givenAView()
+        every { runBlocking { islogged() } } returns token.right()
+
+        presenter.onStart()
+
+        verifyOrder {
+            view.showLoading()
+            view.hideLoading()
+            view.navigateToLoggedScreen()
+        }
+    }
+
+    @Test
+    fun `View should show and hide loading and show logging form when starts and a Token is not stored`() {
+        givenAView()
+        every { runBlocking { islogged() } } returns TokenNotFound.left()
+
+        presenter.onStart()
+
+        verifyOrder {
+            view.showLoading()
+            view.hideLoading()
+            view.showLoginForm()
         }
     }
 

--- a/app/src/test/java/com/ikarimeister/loginapp/ui/presenter/LoginPresenterTest.kt
+++ b/app/src/test/java/com/ikarimeister/loginapp/ui/presenter/LoginPresenterTest.kt
@@ -6,6 +6,9 @@ import com.ikarimeister.loginapp.domain.model.*
 import com.ikarimeister.loginapp.domain.usecases.IsLoginStored
 import com.ikarimeister.loginapp.domain.usecases.Login
 import com.ikarimeister.loginapp.ui.view.LoginView
+import com.ikarimeister.loginapp.utils.MotherObject.email
+import com.ikarimeister.loginapp.utils.MotherObject.password
+import com.ikarimeister.loginapp.utils.MotherObject.token
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -101,12 +104,5 @@ class LoginPresenterTest {
         every { view.hideLoading() } returns Unit
         every { view.showLoginError(any()) } returns Unit
         every { view.navigateToLoggedScreen() } returns Unit
-    }
-
-    companion object {
-        private val email = Email("john.doe@company.com")
-        private val password = Password("123456")
-        private val token = Token("fdskjflsdjflsdjf")
-        private val user = User(email, password)
     }
 }

--- a/app/src/test/java/com/ikarimeister/loginapp/utils/MotherObject.kt
+++ b/app/src/test/java/com/ikarimeister/loginapp/utils/MotherObject.kt
@@ -1,0 +1,15 @@
+package com.ikarimeister.loginapp.utils
+
+import com.ikarimeister.loginapp.domain.model.Email
+import com.ikarimeister.loginapp.domain.model.Password
+import com.ikarimeister.loginapp.domain.model.Token
+import com.ikarimeister.loginapp.domain.model.User
+
+object MotherObject {
+    const val ANY_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+    val email = Email("john.doe@company.com")
+    val password = Password("123456")
+    val token = Token(ANY_TOKEN)
+    val otherToken = Token("gdfgdfgdfgkfñdlgk")
+    val user = User(email, password)
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #10 #14

### :tophat: What is the goal?

When the app starts token will be requested to the storage, if it exists the app will show the logged screen, if not it will show the login window.

### :memo: How is it being implemented?

A use case has been added to retrieve the token from the repository. The use case returns Either so if its Right the app will navigate to the next screen, if it's left it will show the login form.

### :boom: How can it be tested?

_If it cannot be tested explain why._

- [x] **Automatic login:** When presenter starts, if there is a token stored, it will navigate to a logged screen
- [x] **Show Login Form** When login presenter starts it will show login form if there is no token stored.


### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!