### PR TITLE
Added logout logic 🛠

### DIFF
--- a/app/src/main/java/com/ikarimeister/loginapp/domain/usecases/Logout.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/domain/usecases/Logout.kt
@@ -1,0 +1,15 @@
+package com.ikarimeister.loginapp.domain.usecases
+
+import arrow.core.Either
+import arrow.core.extensions.either.monad.flatten
+import com.ikarimeister.loginapp.data.TokenRepository
+import com.ikarimeister.loginapp.domain.model.StorageError
+
+class Logout(private val repository: TokenRepository = Companion.repository) {
+
+    suspend operator fun invoke(): Either<StorageError, Unit> = repository.get().map { repository - it }.flatten()
+
+    companion object {
+        private val repository by lazy { TokenRepository() }
+    }
+}

--- a/app/src/test/java/com/ikarimeister/loginapp/domain/usecases/LogoutTest.kt
+++ b/app/src/test/java/com/ikarimeister/loginapp/domain/usecases/LogoutTest.kt
@@ -1,0 +1,63 @@
+package com.ikarimeister.loginapp.domain.usecases
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import com.ikarimeister.loginapp.data.TokenRepository
+import com.ikarimeister.loginapp.domain.model.StorageError
+import com.ikarimeister.loginapp.domain.model.TokenNotFound
+import com.ikarimeister.loginapp.domain.model.UnknownStorageError
+import com.ikarimeister.loginapp.utils.MotherObject.token
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class LogoutTest {
+
+    @MockK
+    lateinit var repository: TokenRepository
+
+    lateinit var logout: Logout
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        logout = Logout(repository)
+    }
+
+    @Test
+    fun `should remove the token from repository if present and return Right Unit`() = runBlockingTest {
+        every { repository.get() } returns token.right()
+        every { repository - token } returns Unit.right()
+
+        val actual = logout()
+
+        Assert.assertTrue(actual is Either.Right<Unit>)
+    }
+
+    @Test
+    fun `should return TokenNotFound if repository is empty`() = runBlockingTest {
+        every { repository.get() } returns TokenNotFound.left()
+
+        val actual = logout()
+
+        Assert.assertTrue(actual is Either.Left<StorageError>)
+        actual.mapLeft { Assert.assertEquals(TokenNotFound, it) }
+    }
+
+    @Test
+    fun `should return UnknownStorageError if there is any problem removing the token`() = runBlockingTest {
+        every { repository.get() } returns token.right()
+        val throwable = Exception()
+        every { repository - token } returns UnknownStorageError(throwable).left()
+
+        val actual = logout()
+
+        Assert.assertTrue(actual is Either.Left<StorageError>)
+        actual.mapLeft { Assert.assertTrue(it is UnknownStorageError) }
+    }
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:**#30
* **Related pull-requests:** #20 

### :tophat: What is the goal?

In order to do logout, there will be a use case to remove the token from storage

### :memo: How is it being implemented?

A use case has been added to remove the token from the repository. The use case returns Either so if its Right the app will go to the login form if it's left it will show the error

### :boom: How can it be tested?

All the scenarios are covered by automated tests.

- [x] **Scenario 1:** should remove the token from the repository if present and return Right Unit
- [x] **Scenario 2:** should return TokenNotFound if the repository is empty
- [x] **Scenario 3:** should return UnknownStorageError if there is any problem removing the token


### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!