### PR TITLE
Add Validation messages 👮‍♂️

### DIFF
--- a/app/src/androidTest/java/com/ikarimeister/loginapp/ui/activities/LoginActivityTest.kt
+++ b/app/src/androidTest/java/com/ikarimeister/loginapp/ui/activities/LoginActivityTest.kt
@@ -13,6 +13,8 @@ import com.ikarimeister.loginapp.ui.presenter.LoginPresenter
 import com.ikarimeister.loginapp.ui.view.LoginView
 import com.ikarimeister.loginapp.utils.di.resetDI
 import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions
+import com.schibsted.spain.barista.interaction.BaristaClickInteractions
+import com.schibsted.spain.barista.interaction.BaristaEditTextInteractions
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.impl.annotations.MockK
@@ -54,6 +56,24 @@ class LoginActivityTest : ActivityTest<LoginActivity>(LoginActivity::class.java)
         BaristaVisibilityAssertions.assertDisplayed(R.id.password)
         BaristaVisibilityAssertions.assertDisplayed(R.id.username)
         BaristaVisibilityAssertions.assertDisplayed(R.id.imageView)
+        BaristaVisibilityAssertions.assertNotDisplayed(R.id.error)
+        BaristaVisibilityAssertions.assertNotDisplayed(R.id.loading)
+    }
+
+    @Test
+    fun showValidationErrorsWhenTokenIsNotStoredAndInputDataIsInvalid() {
+        coEvery { isLoginStored() } returns TokenNotFound.left()
+
+        startActivity()
+        BaristaEditTextInteractions.writeTo(R.id.username, "not An Email")
+        BaristaEditTextInteractions.writeTo(R.id.password, "A really too long password, really really long")
+        BaristaClickInteractions.clickOn(R.id.login)
+
+        BaristaVisibilityAssertions.assertDisplayed(R.id.login)
+        BaristaVisibilityAssertions.assertDisplayed(R.id.password)
+        BaristaVisibilityAssertions.assertDisplayed(R.id.username)
+        BaristaVisibilityAssertions.assertDisplayed(R.id.imageView)
+        BaristaVisibilityAssertions.assertDisplayed(R.id.error)
         BaristaVisibilityAssertions.assertNotDisplayed(R.id.loading)
     }
 }

--- a/app/src/main/java/com/ikarimeister/loginapp/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/ui/activities/LoginActivity.kt
@@ -3,11 +3,20 @@ package com.ikarimeister.loginapp.ui.activities
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import com.ikarimeister.loginapp.R
 import com.ikarimeister.loginapp.databinding.ActivityLoginBinding
 import com.ikarimeister.loginapp.domain.model.Email
+import com.ikarimeister.loginapp.domain.model.EmailValidationErrors
 import com.ikarimeister.loginapp.domain.model.LoginError
+import com.ikarimeister.loginapp.domain.model.NotAnEmail
+import com.ikarimeister.loginapp.domain.model.NotValidCharsInEmail
 import com.ikarimeister.loginapp.domain.model.Password
+import com.ikarimeister.loginapp.domain.model.PasswordValidationErrors
+import com.ikarimeister.loginapp.domain.model.TooLongEmail
+import com.ikarimeister.loginapp.domain.model.TooLongPassword
+import com.ikarimeister.loginapp.domain.model.TooShortPassword
 import com.ikarimeister.loginapp.domain.model.ValidationErrors
+import com.ikarimeister.loginapp.ui.model.ValidationMessage
 import com.ikarimeister.loginapp.ui.presenter.LoginPresenter
 import com.ikarimeister.loginapp.ui.view.LoginView
 import org.koin.androidx.scope.lifecycleScope
@@ -45,7 +54,27 @@ class LoginActivity : AppCompatActivity(), LoginView {
     }
 
     override fun showError(errors: List<ValidationErrors>) {
-        TODO()
+        val messages = errors.fold(ValidationMessage()) { acc, element ->
+            when (element) {
+                is EmailValidationErrors -> {
+                    val message = when (element) {
+                        NotAnEmail -> R.string.not_an_email
+                        NotValidCharsInEmail -> R.string.not_valid_email
+                        TooLongEmail -> R.string.too_long_email
+                    }
+                    acc.copy(emailError = "${getString(message)}\n${acc.emailError}".trim())
+                }
+                is PasswordValidationErrors -> {
+                    val message = when (element) {
+                        TooLongPassword -> R.string.too_long_password
+                        TooShortPassword -> R.string.too_short_password
+                    }
+                    acc.copy(passwordError = "${acc.passwordError}\n${getString(message)}")
+                }
+            }
+        }
+        binding.error.visibility = View.VISIBLE
+        binding.error.text = "${messages.passwordError}\n${messages.emailError}".trim()
     }
 
     override fun navigateToLoggedScreen() {
@@ -54,6 +83,7 @@ class LoginActivity : AppCompatActivity(), LoginView {
 
     override fun showLoginForm() {
         binding.loading.visibility = View.GONE
+        binding.error.visibility = View.GONE
         binding.login.visibility = View.VISIBLE
         binding.password.visibility = View.VISIBLE
         binding.imageView.visibility = View.VISIBLE

--- a/app/src/main/java/com/ikarimeister/loginapp/ui/model/ValidationMessage.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/ui/model/ValidationMessage.kt
@@ -1,0 +1,3 @@
+package com.ikarimeister.loginapp.ui.model
+
+data class ValidationMessage(val emailError: String = "", val passwordError: String = "")

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -49,7 +49,7 @@
             android:text="@string/action_sign_in"
             app:layout_constraintTop_toBottomOf="@+id/password"
             app:layout_constraintStart_toStartOf="@id/password"
-            app:layout_constraintEnd_toEndOf="@id/midlle_horizontal"
+            app:layout_constraintEnd_toEndOf="@id/middle_horizontal"
             android:textColor="@color/primaryTextColor"
             android:background="@color/primaryColor"
             android:layout_marginTop="48dp"
@@ -85,21 +85,23 @@
     <androidx.constraintlayout.widget.Guideline
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:id="@+id/midlle_horizontal"
+        android:id="@+id/middle_horizontal"
         app:layout_constraintGuide_percent="0.5"
         android:orientation="vertical"/>
-    <androidx.constraintlayout.widget.Guideline
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/start_image"
-        app:layout_constraintGuide_percent="0.33"
-        android:orientation="vertical"/>
-    <androidx.constraintlayout.widget.Guideline
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/end_image"
-        app:layout_constraintGuide_percent="0.66"
-        android:orientation="vertical"/>
+    <TextView android:layout_width="0dp"
+              android:layout_height="0dp"
+              app:layout_constraintTop_toBottomOf="@id/imageView"
+              android:layout_marginTop="@dimen/activity_vertical_margin"
+              android:layout_marginBottom="@dimen/activity_vertical_margin"
+              app:layout_constraintBottom_toTopOf="@id/username"
+              app:layout_constraintStart_toStartOf="@id/username"
+              app:layout_constraintEnd_toEndOf="@id/username"
+              android:gravity="bottom"
+              android:textColor="@color/secondaryColor"
+              android:id="@+id/error"
+              app:layout_constraintVertical_bias="0.7"
+    />
+
 
     <androidx.constraintlayout.widget.Guideline
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <resources>
     <string name="app_name">LoginApp</string>
-    <string name="title_activity_login">Sign in</string>
     <string name="prompt_email">Email</string>
     <string name="prompt_password">Password</string>
     <string name="action_sign_in">Login</string>
@@ -9,4 +8,9 @@
     <string name="invalid_username">Not a valid username</string>
     <string name="invalid_password">Password must be >5 characters</string>
     <string name="login_failed">"Login failed"</string>
+    <string name="not_an_email">Not a valid email address</string>
+    <string name="not_valid_email">Not a valid email address or forbidden characters</string>
+    <string name="too_long_email">Email cannot be >255 characters</string>
+    <string name="too_long_password">Password cannot be >16 characters</string>
+    <string name="too_short_password">Password should be >6 characters</string>
 </resources>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #10, #24, Fixes: #26 
* **Related pull-requests:** #33

### :tophat: What is the goal?

UI should show the validation error messages following platform guidelines

### :memo: How is it being implemented?

Matching Validation error hierarchy with its message from strings.xml

```kotlin
val messages = errors.fold(ValidationMessage()) { acc, element ->
            when (element) {
                is EmailValidationErrors -> {
                    val message = when (element) {
                        NotAnEmail -> R.string.not_an_email
                        NotValidCharsInEmail -> R.string.not_valid_email
                        TooLongEmail -> R.string.too_long_email
                    }
                    acc.copy(emailError = "${getString(message)}\n${acc.emailError}".trim())
                }
                is PasswordValidationErrors -> {
                    val message = when (element) {
                        TooLongPassword -> R.string.too_long_password
                        TooShortPassword -> R.string.too_short_password
                    }
                    acc.copy(passwordError = "${acc.passwordError}\n${getString(message)}")
                }
            }
        }
```

### :boom: How can it be tested?

Automated tests are set up

- [ ] **Validation Messages**
  - [ ] Type a short password <=4 characters and press login button
  - [ ] Validation messages will show

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.

### :art: UI changes?

- [ ] Yeap, here you have some screenshots-

![device-2020-07-25-223758](https://user-images.githubusercontent.com/19489766/88465952-91e8fa80-cec7-11ea-8969-8ee9a46e9499.png)