### PR TITLE
Leaks

### DIFF
--- a/.github/workflows/UITests.yml
+++ b/.github/workflows/UITests.yml
@@ -29,6 +29,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         name: unit-test-reports
+        if:  ${{ always() }}
         with:
           name: unit-test-reports
           path: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,6 +26,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         name: unit-test-reports
+        if:  ${{ always() }}
         with:
           name: unit-test-reports
           path: |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/github/license/IkariMeister/LoginApp.svg?style=flat-square)](LICENSE)
 [![ktlint](https://img.shields.io/badge/code%20style-%E2%9D%A4-FF4081.svg)](https://ktlint.github.io/)
 [![Android CI](https://github.com/Ikarimeister/LoginApp/workflows/Android%20CI/badge.svg)](https://github.com/Ikarimeister/LoginApp/actions)
-[![Build Status](https://travis-ci.com/IkariMeister/LoginApp.svg?branch=master)](https://travis-ci.com/IkariMeister/LoginApp)
+[![Android Test](https://github.com/IkariMeister/LoginApp/workflows/Android%20Test/badge.svg)](https://github.com/Ikarimeister/LoginApp/actions)
 
 Simple login
 
@@ -81,7 +81,20 @@ For the threading problem, `kotlinx.Coroutines` are the solution chosen as **Int
 
 For the presentation layer, **MVP** pattern is the chosen implementation because is the most familiar implementation for the development team, we could consider moving to **MVVM** with data binding, but our expertise and confidence with MVP make us feel more comfortable.
 
-User validation has been implemented by using `ValidatedNel` applicative from `Arrow` library. The validation process will be accumulative and will show all errors found.
+Views are stored as WeakReferences to avoid retain its instance and provoke a memory leak. A `by weak`delegate has been added. Full credits to [this repo](https://github.com/Karumi/KataScreenshotKotlin)
+
+```kotlin
+fun <T> weak(value: T) = WeakRef(value)
+
+class WeakRef<out T>(value: T) {
+    private val weakReference: WeakReference<T> = WeakReference(value)
+    operator fun getValue(thisRef: Any, property: KProperty<*>): T? = weakReference.get()
+}
+
+private val view by weak(view)
+```
+                                                                                                                                                        
+User validation has been implemented by using `ValidatedNel` applicative from `Arrow` library. The validation process will be accumulative and will showall errors found.
 
 Rules that have been implemented are:
 * Email length less than 256 characters,
@@ -131,6 +144,8 @@ companion object {
     }
 ```
 Styles and theming has been defined following `Material Design` design system. For further information check [Material Design Page](https://material.io/)
+
+`leak canary has been added to the UI Tests, from now UI will fail if a memory leak is detected.
 
 
 ### Dependency supplying

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,6 +15,7 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "com.karumi.shot.ShotTestRunner"
+        testInstrumentationRunnerArgument "listener", "leakcanary.FailTestOnLeakRunListener"
     }
 
     compileOptions {
@@ -54,7 +55,7 @@ dependencies {
     implementation "com.google.code.gson:gson:$gson_version"
     implementation "org.koin:koin-android:$koin_version"
     implementation "org.koin:koin-androidx-scope:$koin_version"
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.4'
+    debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakcanary_version"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
     testImplementation "junit:junit:$junit_version"
     testImplementation "io.kotlintest:kotlintest:$kotlintest_version"
@@ -62,6 +63,7 @@ dependencies {
     testImplementation "com.squareup.okhttp3:mockwebserver:$mockwebserver_version"
     testImplementation "commons-io:commons-io:$commonsio_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
+    androidTestImplementation "com.squareup.leakcanary:leakcanary-android-instrumentation:$leakcanary_version"
     androidTestImplementation "io.mockk:mockk-android:$mockk_version"
     androidTestImplementation "com.github.tmurakami:dexopener:$dexopener_version"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espresso_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,7 +41,6 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.core:core-ktx:$corektx_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
@@ -55,6 +54,7 @@ dependencies {
     implementation "com.google.code.gson:gson:$gson_version"
     implementation "org.koin:koin-android:$koin_version"
     implementation "org.koin:koin-androidx-scope:$koin_version"
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.4'
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
     testImplementation "junit:junit:$junit_version"
     testImplementation "io.kotlintest:kotlintest:$kotlintest_version"

--- a/app/src/androidTest/java/com/ikarimeister/loginapp/ui/activities/LoginActivityTest.kt
+++ b/app/src/androidTest/java/com/ikarimeister/loginapp/ui/activities/LoginActivityTest.kt
@@ -25,6 +25,7 @@ import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.Dispatchers
+import leakcanary.FailTestOnLeak
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -39,7 +40,7 @@ class LoginActivityTest : ActivityTest<LoginActivity>(LoginActivity::class.java)
 
     @MockK
     lateinit var isLoginStored: IsLoginStored
-    private lateinit var loginScopeMock : Module
+    private lateinit var loginScopeMock: Module
 
     @Before
     fun setUp() {
@@ -62,6 +63,7 @@ class LoginActivityTest : ActivityTest<LoginActivity>(LoginActivity::class.java)
     }
 
     @Test
+    @FailTestOnLeak
     fun showLoginFormWhenTokenIsNotStored() {
         coEvery { isLoginStored() } returns TokenNotFound.left()
 
@@ -76,6 +78,7 @@ class LoginActivityTest : ActivityTest<LoginActivity>(LoginActivity::class.java)
     }
 
     @Test
+    @FailTestOnLeak
     fun showValidationErrorsWhenTokenIsNotStoredAndInputDataIsInvalid() {
         coEvery { isLoginStored() } returns TokenNotFound.left()
 
@@ -94,6 +97,7 @@ class LoginActivityTest : ActivityTest<LoginActivity>(LoginActivity::class.java)
     }
 
     @Test
+    @FailTestOnLeak
     fun showValidationErrorsOnPaswordWhenTokenIsNotStoredAndInputPaswordIsInvalid() {
         coEvery { isLoginStored() } returns TokenNotFound.left()
 
@@ -112,6 +116,7 @@ class LoginActivityTest : ActivityTest<LoginActivity>(LoginActivity::class.java)
     }
 
     @Test
+    @FailTestOnLeak
     fun showValidationErrorsOnEmailWhenTokenIsNotStoredAndInputEmailIsInvalid() {
         coEvery { isLoginStored() } returns TokenNotFound.left()
 
@@ -130,6 +135,7 @@ class LoginActivityTest : ActivityTest<LoginActivity>(LoginActivity::class.java)
     }
 
     @Test
+    @FailTestOnLeak
     fun showIncorrectCredentialsMessageWhenApiReturnANotValidLoginResponse() {
         coEvery { isLoginStored() } returns TokenNotFound.left()
         coEvery { loginMock(any()) } returns IncorrectCredentials.left()
@@ -149,6 +155,7 @@ class LoginActivityTest : ActivityTest<LoginActivity>(LoginActivity::class.java)
     }
 
     @Test
+    @FailTestOnLeak
     fun showSnackBarWhenThereIsNoConnection() {
         coEvery { isLoginStored() } returns TokenNotFound.left()
         coEvery { loginMock(any()) } returns NoConection.left()

--- a/app/src/androidTest/java/com/ikarimeister/loginapp/ui/activities/LoginActivityTest.kt
+++ b/app/src/androidTest/java/com/ikarimeister/loginapp/ui/activities/LoginActivityTest.kt
@@ -25,8 +25,10 @@ import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.Dispatchers
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.koin.core.module.Module
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
@@ -37,11 +39,12 @@ class LoginActivityTest : ActivityTest<LoginActivity>(LoginActivity::class.java)
 
     @MockK
     lateinit var isLoginStored: IsLoginStored
+    private lateinit var loginScopeMock : Module
 
     @Before
     fun setUp() {
         MockKAnnotations.init(this)
-        val loginScopeMock = module {
+        loginScopeMock = module {
             scope(named<LoginActivity>()) {
                 factory { (view: LoginView) ->
                     LoginPresenter(view, loginMock, isLoginStored, Dispatchers.Unconfined, Dispatchers.Unconfined)
@@ -50,6 +53,12 @@ class LoginActivityTest : ActivityTest<LoginActivity>(LoginActivity::class.java)
         }
         val app = InstrumentationRegistry.getInstrumentation().targetContext.asApp()
         app.resetDI(listOf(scopesModule), listOf(loginScopeMock))
+    }
+
+    @After
+    fun tearDown() {
+        val app = InstrumentationRegistry.getInstrumentation().targetContext.asApp()
+        app.resetDI(listOf(loginScopeMock), listOf(scopesModule))
     }
 
     @Test

--- a/app/src/androidTest/java/com/ikarimeister/loginapp/ui/activities/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/ikarimeister/loginapp/ui/activities/MainActivityTest.kt
@@ -17,8 +17,10 @@ import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.Dispatchers
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.koin.core.module.Module
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
@@ -26,11 +28,12 @@ class MainActivityTest : ActivityTest<MainActivity>(MainActivity::class.java) {
 
     @MockK
     lateinit var logoutMock: Logout
+    private lateinit var mainScopeMock : Module
 
     @Before
     fun setUp() {
         MockKAnnotations.init(this)
-        val mainScopeMock = module {
+        mainScopeMock = module {
             scope(named<MainActivity>()) {
                 factory { (view: MainView) ->
                     MainPresenter(view, logoutMock, Dispatchers.Unconfined, Dispatchers.Unconfined)
@@ -39,6 +42,12 @@ class MainActivityTest : ActivityTest<MainActivity>(MainActivity::class.java) {
         }
         val app = InstrumentationRegistry.getInstrumentation().targetContext.asApp()
         app.resetDI(listOf(scopesModule), listOf(mainScopeMock))
+    }
+
+    @After
+    fun tearDown() {
+        val app = InstrumentationRegistry.getInstrumentation().targetContext.asApp()
+        app.resetDI(listOf(mainScopeMock), listOf(scopesModule))
     }
 
     @Test

--- a/app/src/androidTest/java/com/ikarimeister/loginapp/ui/activities/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/ikarimeister/loginapp/ui/activities/MainActivityTest.kt
@@ -17,6 +17,7 @@ import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.Dispatchers
+import leakcanary.FailTestOnLeak
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -28,7 +29,7 @@ class MainActivityTest : ActivityTest<MainActivity>(MainActivity::class.java) {
 
     @MockK
     lateinit var logoutMock: Logout
-    private lateinit var mainScopeMock : Module
+    private lateinit var mainScopeMock: Module
 
     @Before
     fun setUp() {
@@ -51,6 +52,7 @@ class MainActivityTest : ActivityTest<MainActivity>(MainActivity::class.java) {
     }
 
     @Test
+    @FailTestOnLeak
     fun showErrorWhenLogoutReturnsError() {
         coEvery { logoutMock() } returns TokenNotFound.left()
 
@@ -61,6 +63,7 @@ class MainActivityTest : ActivityTest<MainActivity>(MainActivity::class.java) {
     }
 
     @Test
+    @FailTestOnLeak
     fun activityShowsWelcomeMessageAndLogoutButton() {
         coEvery { logoutMock() } returns TokenNotFound.left()
 

--- a/app/src/main/java/com/ikarimeister/loginapp/commons/WeakRef.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/commons/WeakRef.kt
@@ -1,0 +1,16 @@
+package com.ikarimeister.loginapp.commons
+
+import java.lang.ref.WeakReference
+import kotlin.reflect.KProperty
+
+/**
+ * Used as weakReference delegate for views not to leak the view
+ * Taken from https://github.com/Karumi/KataSuperHeroesKotlin/
+ */
+
+fun <T> weak(value: T) = WeakRef(value)
+
+class WeakRef<out T>(value: T) {
+    private val weakReference: WeakReference<T> = WeakReference(value)
+    operator fun getValue(thisRef: Any, property: KProperty<*>): T? = weakReference.get()
+}

--- a/app/src/main/java/com/ikarimeister/loginapp/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/ui/activities/LoginActivity.kt
@@ -41,6 +41,7 @@ class LoginActivity : AppCompatActivity(), LoginView {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
+        lifecycle.addObserver(presenter)
         presenter.onStart()
     }
 
@@ -96,8 +97,6 @@ class LoginActivity : AppCompatActivity(), LoginView {
         }
         binding.username.error = messages.emailError
         binding.password.error = messages.passwordError
-//        binding.error.visibility = View.VISIBLE
-//        binding.error.text = "${messages.passwordError}\n${messages.emailError}".trim()
     }
 
     override fun navigateToLoggedScreen() {

--- a/app/src/main/java/com/ikarimeister/loginapp/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/ui/activities/MainActivity.kt
@@ -26,6 +26,7 @@ class MainActivity : AppCompatActivity(), MainView {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
+        lifecycle.addObserver(presenter)
         binding.logout.setOnClickListener { presenter.doLogout() }
     }
 

--- a/app/src/main/java/com/ikarimeister/loginapp/ui/presenter/LoginPresenter.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/ui/presenter/LoginPresenter.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 import arrow.core.Nel
+import com.ikarimeister.loginapp.commons.weak
 import com.ikarimeister.loginapp.domain.model.Email
 import com.ikarimeister.loginapp.domain.model.Password
 import com.ikarimeister.loginapp.domain.model.User
@@ -17,12 +18,15 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class LoginPresenter(
-    private val view: LoginView?,
+    view: LoginView,
     private val login: Login,
     private val isLoginStored: IsLoginStored,
     private val bgDispatcher: CoroutineDispatcher,
     uiDispacher: CoroutineDispatcher
 ) : LifecycleObserver, Scope by Scope.Impl(uiDispacher) {
+
+    private val view by weak(view)
+
     init {
         startPresenter()
     }

--- a/app/src/main/java/com/ikarimeister/loginapp/ui/presenter/MainPresenter.kt
+++ b/app/src/main/java/com/ikarimeister/loginapp/ui/presenter/MainPresenter.kt
@@ -3,6 +3,7 @@ package com.ikarimeister.loginapp.ui.presenter
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
+import com.ikarimeister.loginapp.commons.weak
 import com.ikarimeister.loginapp.domain.usecases.Logout
 import com.ikarimeister.loginapp.ui.coomons.Scope
 import com.ikarimeister.loginapp.ui.view.MainView
@@ -11,11 +12,13 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class MainPresenter(
-    private val view: MainView?,
+    view: MainView,
     private val logout: Logout,
     private val bgDispatcher: CoroutineDispatcher,
     uiDispacher: CoroutineDispatcher
 ) : LifecycleObserver, Scope by Scope.Impl(uiDispacher) {
+
+    private val view by weak(view)
 
     init {
         startPresenter()

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -17,6 +17,7 @@ ext {
     kotlin_version = '1.3.72'
     kotlintest_version = "2.0.7"
     ktlint_version = '0.34.2'
+    leakcanary_version = "2.4"
     lifecycle_version = "2.2.0"
     material_version = "1.1.0"
     mockito_version = "2.2.0"


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Fixes: #47 

### :tophat: What is the goal?

Set up tools for watching about memory leaks, like leak canary. Also during the implementation, several bugs related have shown up like not saving views as WeakReferences or not initializing lifecycle observers

### :memo: How is it being implemented?

A Weak reference delegate has been implemented, inspired by [Karumi/KataScreenshotKotlin](https://github.com/Karumi/KataScreenshotKotlin)
```kotlin
fun <T> weak(value: T) = WeakRef(value)

class WeakRef<out T>(value: T) {
    private val weakReference: WeakReference<T> = WeakReference(value)
    operator fun getValue(thisRef: Any, property: KProperty<*>): T? = weakReference.get()
}

private val view by weak(view)
```

Also `leak canary` has been added to the UI Tests, from now UI will fail if a memory leak is detected.

### :boom: How can it be tested?

`leak canary` has been added to UI tests

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!